### PR TITLE
Network log entry UI improvement

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -150,8 +150,8 @@ class HomePageState extends State<HomePage> {
                 const SizedBox(height: 12),
                 FilledButton.tonal(
                   onPressed: () async {
-                    await _dio
-                        .get('https://jsonplaceholder.typicode.com/posts');
+                    await _dio.get(
+                        'https://jsonplaceholder.typicode.com/posts?query=123&query2=456&query3=789');
                   },
                   child: const Text('GET'),
                 ),

--- a/lib/src/console/logarte_entry_item.dart
+++ b/lib/src/console/logarte_entry_item.dart
@@ -200,16 +200,26 @@ class _NetworkItem extends StatelessWidget {
         children: [
           const SizedBox(height: 4.0),
           RichText(
-              maxLines: 2,
-              text: TextSpan(children: [
+            maxLines: 2,
+            text: TextSpan(
+              children: [
                 TextSpan(
-                    text: host,
-                    style: const TextStyle(fontSize: 14.0, color: Colors.grey)),
+                  text: host,
+                  style: const TextStyle(
+                    fontSize: 14.0,
+                    color: Colors.blueGrey,
+                  ),
+                ),
                 TextSpan(
-                    text: nonHost,
-                    style:
-                        const TextStyle(fontSize: 14.0, color: Colors.black)),
-              ])),
+                  text: nonHost,
+                  style: const TextStyle(
+                    fontSize: 14.0,
+                    color: Colors.black,
+                  ),
+                ),
+              ],
+            ),
+          ),
           const SizedBox(height: 4.0),
           Text(
             '${entry.timeFormatted} • ${entry.asReadableDuration} • ${entry.response.body.toString().asReadableSize}',

--- a/lib/src/console/logarte_entry_item.dart
+++ b/lib/src/console/logarte_entry_item.dart
@@ -151,6 +151,13 @@ class _NetworkItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final url = Uri.parse(entry.request.url);
+    final host = '${url.scheme}://${url.host}';
+    final nonHost = entry.request.url.replaceAll(host, '');
+    final isSuccess = entry.response.statusCode != null &&
+        entry.response.statusCode! >= 200 &&
+        entry.response.statusCode! < 300;
+
     return ListTile(
       onTap: () {
         Navigator.of(context).push(
@@ -166,30 +173,23 @@ class _NetworkItem extends StatelessWidget {
         );
       },
       title: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Icon(
-            entry.response.statusCode == null
-                ? Icons.public_off_rounded
-                : entry.response.statusCode! >= 200 &&
-                        entry.response.statusCode! < 300
-                    ? Icons.public_rounded
-                    : Icons.public_off_rounded,
-            color: entry.response.statusCode == null
-                ? Colors.grey
-                : entry.response.statusCode! >= 200 &&
-                        entry.response.statusCode! < 300
-                    ? Colors.green
-                    : Colors.red,
-            size: 20.0,
-          ),
-          const SizedBox(width: 8.0),
-          Text(
-            entry.request.method,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2,
-            style: const TextStyle(
-              fontSize: 14.0,
-              fontWeight: FontWeight.w600,
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6.0, vertical: 3.0),
+            decoration: BoxDecoration(
+              color: isSuccess ? Colors.green : Colors.red,
+              borderRadius: BorderRadius.circular(8.0),
+            ),
+            child: Text(
+              '${entry.response.statusCode} - ${entry.request.method}',
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+              style: const TextStyle(
+                fontSize: 10.0,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+              ),
             ),
           ),
         ],
@@ -198,22 +198,24 @@ class _NetworkItem extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          const SizedBox(height: 4.0),
+          RichText(
+              maxLines: 2,
+              text: TextSpan(children: [
+                TextSpan(
+                    text: host,
+                    style: const TextStyle(fontSize: 14.0, color: Colors.grey)),
+                TextSpan(
+                    text: nonHost,
+                    style:
+                        const TextStyle(fontSize: 14.0, color: Colors.black)),
+              ])),
+          const SizedBox(height: 4.0),
           Text(
-            // TODO: can also display the path
-            entry.request.url,
-            // Uri.parse(entry.request.url).path,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2,
-            style: const TextStyle(fontSize: 14.0),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(top: 2.0),
-            child: Text(
-              '${entry.timeFormatted} • ${'${entry.asReadableDuration} • ${entry.response.body.toString().asReadableSize}'}',
-              style: const TextStyle(
-                fontSize: 12.0,
-                color: Colors.grey,
-              ),
+            '${entry.timeFormatted} • ${entry.asReadableDuration} • ${entry.response.body.toString().asReadableSize}',
+            style: const TextStyle(
+              fontSize: 12.0,
+              color: Colors.grey,
             ),
           ),
         ],


### PR DESCRIPTION
- Add status code as colored chip
- Different color for host vs path/query to improve readibility

|  Before |  After |
| ------ | ----- |
| <img width="376" height="294" alt="Screenshot 2025-07-21 at 15 30 44" src="https://github.com/user-attachments/assets/26068ff2-5135-49eb-a3c3-d9f1d6e75a1e" /> |. <img width="355" height="544" alt="Screenshot 2025-07-23 at 09 13 48" src="https://github.com/user-attachments/assets/770a215e-9882-4da9-984e-115415b3cfe7" /> | 



