### PR TITLE
feat: Support form data on post payload body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+* Add support for `FormData` on POST with multipart payload body
+
 ## 1.3.0
 
 * Add feature `Search and Highlight content in Network Log Details Screen`

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:logarte/logarte.dart';
@@ -172,6 +174,31 @@ class HomePageState extends State<HomePage> {
                         .post('https://jsonplaceholder.typicode.com/posts');
                   },
                   child: const Text('POST'),
+                ),
+                FilledButton.tonal(
+                  onPressed: () async {
+                    // Create dummy file
+                    final tempDir = Directory.systemTemp;
+                    final dummyFile = File('${tempDir.path}/dummy_upload.jpg');
+
+                    // Write random bytes
+                    await dummyFile
+                        .writeAsBytes(List.generate(100, (i) => i % 255));
+
+                    final formData = FormData.fromMap({
+                      "title": "Dummy Post",
+                      "description": "Testing multipart upload",
+                      "user_id": 123,
+                      "image": await MultipartFile.fromFile(dummyFile.path,
+                          filename: "dummy_upload.jpg"),
+                    });
+
+                    await _dio.post(
+                      'https://jsonplaceholder.typicode.com/posts',
+                      data: formData,
+                    );
+                  },
+                  child: const Text('POST With Multipart Body'),
                 ),
                 FilledButton.tonal(
                   onPressed: () async {

--- a/lib/src/extensions/object_extensions.dart
+++ b/lib/src/extensions/object_extensions.dart
@@ -1,13 +1,46 @@
 import 'dart:convert';
+import 'package:dio/dio.dart';
 
 extension LogarteNullableStringXs on Object? {
   String get prettyJson {
     try {
       final source = this;
 
-      return const JsonEncoder.withIndent('  ').convert(
-        source is String ? jsonDecode(source) : this,
-      );
+      if (source == null) {
+        return 'null';
+      }
+
+      // Handle FormData
+      if (source is FormData) {
+        final Map<String, dynamic> data = {};
+
+        // normal fields
+        for (final field in source.fields) {
+          try {
+            data[field.key] = jsonDecode(field.value);
+          } catch(_) {
+            data[field.key] = field.value;
+          }
+        }
+
+        // files
+        for (final file in source.files) {
+          final multipart = file.value;
+
+          data[file.key] = multipart.filename ?? 'file';
+        }
+
+        return const JsonEncoder.withIndent('  ').convert(data);
+      }
+
+      // Handle String JSON
+      if (source is String) {
+        final decoded = jsonDecode(source);
+        return const JsonEncoder.withIndent('  ').convert(decoded);
+      }
+
+      // Handle Map/List
+      return const JsonEncoder.withIndent('  ').convert(source);
     } catch (_) {
       return toString();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: logarte
 description: Powerful in-app debug console for Flutter apps with network inspector, storage monitor, and password protection
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/kamranbekirovyz/logarte
 issue_tracker: https://github.com/kamranbekirovyz/logarte/issues
 homepage: https://bio.kamranbekirov.com


### PR DESCRIPTION
- Support `FormData` on POST payload body
- Log filename for files payload 

 |Before|After|
|----|----|
|<img width="370" height="875" alt="image" src="https://github.com/user-attachments/assets/11b4c713-cd86-47c1-b85a-60987cc42c25" />|<img width="370" height="875" alt="image" src="https://github.com/user-attachments/assets/da77e33e-9248-4218-b8ca-fbf7a2a3ac99" />||